### PR TITLE
Fix Marketo connector leads schema

### DIFF
--- a/airbyte-integrations/connectors/source-marketo/source_marketo/schemas/leads.json
+++ b/airbyte-integrations/connectors/source-marketo/source_marketo/schemas/leads.json
@@ -5,9 +5,6 @@
     "company": {
       "type": ["string", "null"]
     },
-    "site": {
-      "type": ["string", "null"]
-    },
     "billingStreet": {
       "type": ["string", "null"]
     },

--- a/airbyte-integrations/connectors/source-marketo/source_marketo/schemas/leads.json
+++ b/airbyte-integrations/connectors/source-marketo/source_marketo/schemas/leads.json
@@ -2,6 +2,21 @@
   "type": ["object", "null"],
   "additionalProperties": false,
   "properties": {
+    "sfdcAccountId": {
+      "type": ["string", "null"]
+    },
+    "sfdcContactId": {
+      "type": ["string", "null"]
+    },
+    "sfdcLeadId": {
+      "type": ["string", "null"]
+    },
+    "sfdcLeadOwnerId": {
+      "type": ["string", "null"]
+    },
+    "sfdcType": {
+      "type": ["string", "null"]
+    },
     "company": {
       "type": ["string", "null"]
     },


### PR DESCRIPTION
Two main changes:
* Need to read SFDC related attributes
* `site` field springs an error, like so, so this changeset will eliminate it from the schema:
```
        {
            "code": "1003",
            "message": "Invalid fields [site]"
        }
```